### PR TITLE
Fix: Corrige el cálculo del Factor de Bradford para usar episodios.

### DIFF
--- a/data_processor.py
+++ b/data_processor.py
@@ -1219,6 +1219,7 @@ class AttendanceProcessor:
                 "tiene_permiso": True,
                 "tipo_permiso": "No Contratado",
                 "horas_esperadas": "00:00:00",
+                "horas_esperadas_originales": "00:00:00",
                 "tipo_retardo": "No Contratado",
                 "tipo_falta_ajustada": "No Contratado",
                 "minutos_tarde": 0,

--- a/reporte_excel.py
+++ b/reporte_excel.py
@@ -482,6 +482,10 @@ class GeneradorReporteExcel:
 
     def _generar_observaciones(self, row_data):
         """Generar observaciones basadas en los datos de la fila"""
+        # Caso especial para días no contratados, para evitar duplicados en observaciones
+        if row_data.get("tipo_permiso") == "No Contratado":
+            return "No Contratado"
+
         observaciones = []
 
         # Verificar observaciones existentes en el DataFrame

--- a/reporte_excel.py
+++ b/reporte_excel.py
@@ -723,8 +723,10 @@ class AsistenciaAnalyzer:
                 horas_esperadas_netas = horas_esperadas - horas_descontadas
                 
                 # 1. Bradford Factor = S² × D
-                episodios_ausencia = int(row['faltas_del_periodo']) + int(row['faltas_justificadas'])
-                total_dias_ausentes = int(row['total_faltas'])
+                # 'S' son los episodios de ausencia (ya calculados)
+                # 'D' es el total de días de ausencia injustificada
+                episodios_ausencia = int(row.get('episodios_ausencia', 0))
+                total_dias_ausentes = int(row['faltas_del_periodo'])
                 bradford_factor = (episodios_ausencia ** 2) * total_dias_ausentes
                 
                 # 2. Tasa de Ausentismo (%)


### PR DESCRIPTION
Se modifica la lógica para calcular correctamente los episodios de ausencia (S) en lugar de sumar los días de ausencia. Ahora, S representa el número de bloques de ausencias no planificadas.

- Se añade una función en `report_generator.py` para calcular los episodios de ausencia no planificada (`es_falta_ajustada == 1`) y se agrega la columna `episodios_ausencia` al DataFrame de resumen.
- Se actualiza el método `calculate_individual_kpis` en `reporte_excel.py` para usar la nueva columna `episodios_ausencia` en el cálculo del Factor de Bradford.
- Se asegura que D (días de ausencia) en la fórmula del Factor de Bradford solo cuente las ausencias no planificadas (`faltas_del_periodo`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Se incorpora el conteo de episodios de ausencia por empleado y se incluye en resúmenes y reportes (columna “episodios_ausencia”).
- Refactor
  - El Bradford Factor ahora emplea “episodios_ausencia” como S y días de ausencia injustificada como D, alineando el KPI con la métrica.
- Bug Fixes
  - Observaciones devuelven “No Contratado” de forma única, evitando duplicados.
  - Días previos al ingreso registran “horas_esperadas_originales” en 00:00:00, asegurando consistencia en reportes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->